### PR TITLE
Fixing place of colorscheme

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -23,9 +23,9 @@ Plugin 'airblade/vim-gitgutter'
 
 " Color Themes
 Plugin 'flazz/vim-colorschemes'
-colorscheme Monokai
 
 call vundle#end()
+colorscheme Monokai
 filetype plugin indent on
 
 """"""""


### PR DESCRIPTION
'colorscheme Monokai', should be used after 'call vundle#end()' otherwise theme wont be applied after first installation.
This is one of the reasons of the warning about "Monokai".
Other is (if you fix it) warning about "monokai" (note the case change !) , it's because inconsistency of theme's developers i suggested a fix for them too :) [1]

I hope this helps ;)

[1] flazz/vim-colorschemes#98