### PR TITLE
Fix typo in vimrc

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -131,7 +131,7 @@ let g:airline_powerline_fonts = 1
 
 " Find
 map <C-f> /
-" indend / deindent after selecting the text with (⇧ v), (.) to repeat.
+" indent / deindent after selecting the text with (⇧ v), (.) to repeat.
 vnoremap <Tab> >
 vnoremap <S-Tab> <
 " comment / decomment & normal comment behavior


### PR DESCRIPTION
inden~~d~~<ins>t</ins>
